### PR TITLE
Rebuild 0.12.15 for python 3.11

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "maturin" %}
-{% set version = "0.12.20" %}
+{% set version = "0.12.15" %}
 
 package:
   name: {{ name }}
@@ -7,10 +7,10 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 62ef15831f14330aa426c2ccc475c5b8d473bb52731e478e0cb9ab37e137d758
+  sha256: 2ca6222ae70276ba2f2d0c7296804bf62db87fec73198f274f8c1729a3f6c8e5
 
 build:
-  number: 0
+  number: 1
   skip: true  # [py==27]
   missing_dso_whitelist:   # [osx]
     - /usr/lib/libresolv.9.dylib  # [osx]
@@ -22,14 +22,11 @@ requirements:
     - {{ compiler('c') }}              # [unix]
     - {{ compiler('m2w64_c') }}        # [win]
     - {{ compiler('rust') }}
-    - openssl                          # [unix]
   host:
     - pip
-    - setuptools-rust
-    - wheel
+    - setuptools <=60.10.0
     - python
     - tomli >=1.1.0
-    - openssl                          # [unix]
   run:
     - python
     - tomli >=1.1.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "maturin" %}
-{% set version = "1.1.0" %}
+{% set version = "0.12.20" %}
 
 package:
   name: {{ name }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 4650aeaa8debd004b55aae7afb75248cbd4d61cd7da2dcf4ead8b22b58cecae0
+  sha256: 62ef15831f14330aa426c2ccc475c5b8d473bb52731e478e0cb9ab37e137d758
 
 build:
   number: 0


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

This is an older version of maturin that we don't currently have on conda-forge. I'm attempting to build it since `connectorx` pins to `>=0.12,<0.13`, but the available builds satisfying that (latest is `0.12.15`) on conda-forge currently don't support python 3.11. This is blocking `connectorx` from building on python 3.11. `connectorx` is used by `polars` and `modin` for pulling data from a database into a dataframe. This was the last version of pypi before `0.13.0`.

I'm not sure if this should be merged into `main` or a separate branch. 