### PR TITLE
dont enable cross-compile feature

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -16,6 +16,7 @@ set PYTHONIOENCODING="UTF-8"
 REM https://github.com/rust-lang/cargo/issues/10583#issuecomment-1129997984
 set CARGO_NET_GIT_FETCH_WITH_CLI=true
 
-set MATURIN_SETUP_ARGS=--no-default-features --features=full,native-tls
+REM dont enable cross-compile
+set MATURIN_SETUP_ARGS=--no-default-features --features=cli-completion,log,scaffolding,upload,native-tls
 
 %PYTHON% -m pip install . --no-deps --ignore-installed -vv

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -14,7 +14,7 @@ rustc --version
 export CARGO_NET_GIT_FETCH_WITH_CLI=true
 
 export OPENSSL_NO_VENDOR=1
-export MATURIN_SETUP_ARGS="--no-default-features --features=full,native-tls"
+export MATURIN_SETUP_ARGS="--no-default-features --features=cli-completion,log,scaffolding,upload,native-tls" # dont enable cross-compile
 
 # Install wheel manually
 $PYTHON -m pip install . --no-deps --ignore-installed -vv

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,6 +23,7 @@ requirements:
     - {{ compiler('m2w64_c') }}        # [win]
     - {{ compiler('rust') }}
     - openssl                          # [unix]
+    - pkg-config                       # [unix]
   host:
     - pip
     - setuptools-rust

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: f6c69bc7ae147a5effd55587447b35cab1ceb726ba244d08698bc7518b8688ac
 
 build:
-  number: 0
+  number: 1
   skip: true  # [py==27]
   missing_dso_whitelist:   # [osx]
     - /usr/lib/libresolv.9.dylib  # [osx]


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

Maturin uses cargo-xwin by default when compiling from Linux to x86_64_pc_windows_msvc. cargo-xwin then uses a vendored windows-sdk and clang toolchain and modifies the env to set up cross-compilation. This PR disables this feature so we can set up the x86_64_pc_windows_msvc target inside https://github.com/conda-forge/rust-activation-feedstock in general. This feature is only used when compiling from Mac for Windows, which as far as I can tell, no other feedstock currently does.

<!--
Please add any other relevant info below:
-->
